### PR TITLE
enable tls verify to fix rpc-switch clientauth mode

### DIFF
--- a/lib/RPC/Switch/Server.pm
+++ b/lib/RPC/Switch/Server.pm
@@ -17,7 +17,7 @@ sub new {
 		$serveropts->{tls_cert} = $l->{tls_cert};
 	}
 	if ($l->{tls_ca}) {
-		#$serveropts->{tls_verify} = 0; # cheating..
+		$serveropts->{tls_verify} = 3;
 		$serveropts->{tls_ca} = $l->{tls_ca};
 	}
 


### PR DESCRIPTION
Hello Wieger,

without tls_verify mode the rpc-switch will not check a client-cert, and the $c->peer_certificate("cn") field will be empty.
This is the most important fix to get the example for my rpctiny client running (the patch is also included there)
(see: https://metacpan.org/release/BDZ/RPC-Switch-Client-Tiny-1.54/source/examples/Makefile).

Thanks,
Barnim